### PR TITLE
Build with Visual Studio

### DIFF
--- a/src/hello/headers/Hello.h
+++ b/src/hello/headers/Hello.h
@@ -1,5 +1,14 @@
+#pragma once
 
-class Hello 
+#ifdef _MSC_VER
+	#ifdef HELLO_EXPORT
+		#define HELLO_API __declspec(dllexport)
+	#else
+		#define HELLO_API __declspec(dllimport)
+	#endif
+#endif
+
+class HELLO_API Hello
 {
 	private:
 		const char * who;


### PR DESCRIPTION
Hi there,

thank you for the example project.

For me it didn't build out of the box. I was getting a linker error that the `hello.lib` couldn't be found. That lib was never created because by default, Visual Studio doesn't export any symbols. So I added the required `__declspec(dllexport/dllimport)` to the hello header. It should still build on other compilers.

Cheers,
Andreas
